### PR TITLE
fix zone_rankings giving up on exception

### DIFF
--- a/fflogsapi/characters/character.py
+++ b/fflogsapi/characters/character.py
@@ -247,23 +247,26 @@ class FFLogsCharacter:
         jobs = self._client.jobs()
         encounters = []
         for rank in result['rankings']:
-            from ..world.encounter import FFLogsEncounter
-            encounter = FFLogsEncounter(id=rank['encounter']['id'], client=self._client)
-            job = list(filter(lambda j: j.slug == rank['spec'], jobs))[0]
-            best_job = list(filter(lambda j: j.slug == rank['bestSpec'], jobs))[0]
+            try:
+                from ..world.encounter import FFLogsEncounter
+                encounter = FFLogsEncounter(id=rank['encounter']['id'], client=self._client)
+                job = list(filter(lambda j: j.slug == rank['spec'], jobs))[0]
+                best_job = list(filter(lambda j: j.slug == rank['bestSpec'], jobs))[0]
 
-            encounters.append(FFLogsZoneEncounterRanking(
-                locked_in=rank['lockedIn'],
-                encounter=encounter,
-                rank_percent=rank['rankPercent'],
-                median_percent=rank['medianPercent'],
-                best_amount=rank['bestAmount'],
-                fastest_kill=rank['fastestKill'],
-                kills=rank['totalKills'],
-                job=job,
-                best_job=best_job,
-                all_stars=self._make_all_stars_ranking(rank['allStars'], zone=zone, job=job),
-            ))
+                encounters.append(FFLogsZoneEncounterRanking(
+                    locked_in=rank['lockedIn'],
+                    encounter=encounter,
+                    rank_percent=rank['rankPercent'],
+                    median_percent=rank['medianPercent'],
+                    best_amount=rank['bestAmount'],
+                    fastest_kill=rank['fastestKill'],
+                    kills=rank['totalKills'],
+                    job=job,
+                    best_job=best_job,
+                    all_stars=self._make_all_stars_ranking(rank['allStars'], zone=zone, job=job),
+                ))
+            except (IndexError, StopIteration):
+                continue
 
         return FFLogsZoneRanking(
             zone=zone,

--- a/fflogsapi/characters/character.py
+++ b/fflogsapi/characters/character.py
@@ -247,6 +247,9 @@ class FFLogsCharacter:
         jobs = self._client.jobs()
         encounters = []
         for rank in result['rankings']:
+            # TODO: real fixes instead of ignoring the issue
+            # IndexError is from the spec filters on null rankings
+            # StopIteration is from the allstars ranking construction
             try:
                 from ..world.encounter import FFLogsEncounter
                 encounter = FFLogsEncounter(id=rank['encounter']['id'], client=self._client)


### PR DESCRIPTION
Hey there!

It appears `character.zone_rankings` raises an exception and gives up in certain circumstances where it could actually have continued. The result is that valid data that could have been returned is inaccessible.

It may be easier to show some examples.

I wish to retrieve a character's Savage _Median Perf. Avg_. It's visible on their fflogs.com character page.
Setup:
```
from config import CLIENT_ID, CLIENT_SECRET
from fflogsapi import FFLogsClient
client = FFLogsClient(CLIENT_ID, CLIENT_SECRET)
```

Getting a character who has cleared Kokytos and Pandaemonium Savage (on SGE), but not the other fights (_Median Perf. Avg_ still exists, despite not clearing the entire tier.):
```
character = client.get_character({
    'name': 'Blitzen Zero',
    'serverSlug': 'Malboro',
    'serverRegion': 'NA'
})
```
Now, attempt to call `zone_rankings`:
```
zr = character.zone_rankings({
    'byBracket': False,
    'difficulty': 101,
    'specName': 'Sage'
})
```
```
  File "fflogsapi\characters\character.py", line 252, in zone_rankings
    job = list(filter(lambda j: j.slug == rank['spec'], jobs))[0]
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
The method fails: it is trying to access the encounter for Themis, but there is no spec associated with it as it is not cleared.

Proposal:
Keep going, ignoring issues generated by uncleared fights, as there may still be data the caller is interested in. In this case, `median_performance_avg=result['medianPerformanceAverage']` was still obtained and could have been returned if we ignore the Exception generated from uncleared fights.

Another example:
```
character = client.get_character({
    'name': 'Leaf Eon',
    'serverSlug': 'Seraph',
    'serverRegion': 'NA'
})
zr = character.zone_rankings({
    'byBracket': False,
    'difficulty': 101,
    'specName': 'Sage'
})
```
```
  File "fflogsapi\characters\character.py", line 265, in zone_rankings
    all_stars=self._make_all_stars_ranking(rank['allStars'], zone=zone, job=job),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fflogsapi\characters\character.py", line 215, in _make_all_stars_ranking
    partition=next(filter(lambda p: p.id == data['partition'], partitions)),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration
```
An issue with generating the All Stars Ranking for this encounter causes the entire query to fail. (It appears the All Stars rank for Pandaemonium for this character doesn't exist. It's displayed as "-" on the website.) In this case, `median_performance_avg=result['medianPerformanceAverage']` was also still obtained and could have been returned if we ignore the Exception generated from All Stars issues.


I'm lazy, so I surrounded the problem code in question with a try-catch.
Testing after this fix yields correct results:
```
# First case
>>> zr.median_performance_avg
80.3005
# Second case
>>> zr.median_performance_avg
78.74598
```