### PR TITLE
fflogs: user_auth: Fix key path creation

### DIFF
--- a/fflogsapi/user_auth.py
+++ b/fflogsapi/user_auth.py
@@ -57,7 +57,7 @@ class UserModeAuthMixin:
                 self.OAUTH_USER_AUTH_URI,
             )
             # notifying them that their browser will open for login is not really an option
-            input('Press any key to open your browser to authenticate with FF Logs.')
+            input('Press enter to open your browser to authenticate with FF Logs.')
 
             self._generate_ss_x509_cert()
             print(f'You now have {self.CERT_EXPIRY_MINUTES} minutes to complete sign-in.')
@@ -101,7 +101,7 @@ class UserModeAuthMixin:
             .sign(key, hashes.SHA256())
 
         if not os.path.exists(os.path.dirname(self.KEY_PATH)):
-            os.makedirs(self.KEY_PATH)
+            os.makedirs(os.path.dirname(self.KEY_PATH))
         with open(self.KEY_PATH, 'wb') as f:
             f.write(key.private_bytes(
                 encoding=serialization.Encoding.PEM,


### PR DESCRIPTION
If the directory where the keys are to be stored doesn't exist, all the directories leading to that path need to be created. The check if the path exists checks the existence correctly, but the filename itself was also created as a directory leading to user mode being unusable with the following error:

  File "fflogsapi/user_auth.py", line 105, in _generate_ss_x509_cert
    with open(self.KEY_PATH, 'wb') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: './fflogsapi/fflogs_auth_redirect_key.pem'

Fix this by running os.makedirs() on the dirname, and not the full path.

While at it, fix the message telling the user to press "any key", as "any key" does not complete the input() call.